### PR TITLE
Type constraints are stored in @KURA

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,46 @@ Attempt to call undefined import method with arguments ("Foo" ...) via package "
 (Perhaps you forgot to load the package?)
 ```
 
+## ENVIRONMENT VARIABLES
+
+Environment variables `@EXPORT_OK` and `@KURA` are automatically set when you use `kura` in your package:
+
+```perl
+package MyFoo {
+    use Exporter 'import';
+    use Types::Common -types;
+    use kura Foo1 => StrLength[1, 255];
+    use kura Foo2 => StrLength[1, 1000];
+
+    our @EXPORT_OK;
+    push @EXPORT_OK, qw(hello);
+
+    sub hello { 'Hello, Foo!' }
+}
+
+# Automatically set the caller package to MyFoo
+MyFoo::EXPORT_OK # => ('Foo1', 'Foo2', 'hello')
+MyFoo::KURA      # => ('Foo1', 'Foo2')
+```
+
+It is useful when you want to export constraints. For example, you can tag `@KURA` with `%EXPORT_TAGS`:
+
+```perl
+package MyBar {
+    use Exporter 'import';
+    use Types::Common -types;
+    use kura Bar1 => StrLength[1, 255];
+    use kura Bar2 => StrLength[1, 1000];
+
+    our %EXPORT_TAGS = (
+        types => \@MyBar::KURA,
+    );
+}
+
+use MyBar qw(:types);
+# => Bar1, Bar2 are exported
+```
+
 # LICENSE
 
 Copyright (C) kobaken.

--- a/lib/kura.pm
+++ b/lib/kura.pm
@@ -101,8 +101,10 @@ sub _install_constraint {
 
     {
         no strict "refs";
+        no warnings "once";
         *{"$caller\::$name"} = Sub::Util::set_subname( "$caller\::$name", $code);
         push @{"$caller\::EXPORT_OK"}, $name;
+        push @{"$caller\::KURA"}, $name;
     }
 
     return;

--- a/lib/kura.pm
+++ b/lib/kura.pm
@@ -241,6 +241,42 @@ If you forget to put C<use Exporter 'import';>, you get an error like this:
     Attempt to call undefined import method with arguments ("Foo" ...) via package "MyFoo"
     (Perhaps you forgot to load the package?)
 
+=head2 ENVIRONMENT VARIABLES
+
+Environment variables C<@EXPORT_OK> and C<@KURA> are automatically set when you use C<kura> in your package:
+
+    package MyFoo {
+        use Exporter 'import';
+        use Types::Common -types;
+        use kura Foo1 => StrLength[1, 255];
+        use kura Foo2 => StrLength[1, 1000];
+
+        our @EXPORT_OK;
+        push @EXPORT_OK, qw(hello);
+
+        sub hello { 'Hello, Foo!' }
+    }
+
+    # Automatically set the caller package to MyFoo
+    MyFoo::EXPORT_OK # => ('Foo1', 'Foo2', 'hello')
+    MyFoo::KURA      # => ('Foo1', 'Foo2')
+
+It is useful when you want to export constraints. For example, you can tag C<@KURA> with C<%EXPORT_TAGS>:
+
+    package MyBar {
+        use Exporter 'import';
+        use Types::Common -types;
+        use kura Bar1 => StrLength[1, 255];
+        use kura Bar2 => StrLength[1, 1000];
+
+        our %EXPORT_TAGS = (
+            types => \@MyBar::KURA,
+        );
+    }
+
+    use MyBar qw(:types);
+    # => Bar1, Bar2 are exported
+
 =head1 LICENSE
 
 Copyright (C) kobaken.

--- a/t/01-kura.t
+++ b/t/01-kura.t
@@ -9,10 +9,19 @@ subtest 'Test `kura` features' => sub {
         isa_ok X, 'MyConstraint';
     };
 
-    subtest '`kura` with constarint and other function.' => sub {
+    subtest '`kura` with constraint and other function.' => sub {
         use MyFoo qw(Foo hello);
         isa_ok Foo, 'MyConstraint';
         is hello(), 'Hello, Foo!';
+    };
+
+    subtest '`kura` with tags' => sub {
+        use MyBar qw(:types);
+        isa_ok Bar1, 'MyConstraint';
+        isa_ok Bar2, 'MyConstraint';
+        isa_ok Bar3, 'MyConstraint';
+        is \@MyBar::KURA, [qw(Bar1 Bar2 Bar3)], 'types defined by kura are stored in $PACKAGE::KURA';
+        is \@MyBar::EXPORT_OK, [qw(Bar1 Bar2 Bar3 bar_hello)];
     };
 };
 

--- a/t/lib/MyBar.pm
+++ b/t/lib/MyBar.pm
@@ -1,0 +1,21 @@
+package MyBar;
+
+use lib 't/lib';
+use MyConstraint;
+
+use Exporter 'import';
+
+our @EXPORT_OK;
+push @EXPORT_OK, qw(bar_hello);
+
+our %EXPORT_TAGS = (
+    types => \@MyBar::KURA,
+);
+
+use kura Bar1 => MyConstraint->new;
+use kura Bar2 => MyConstraint->new;
+use kura Bar3 => MyConstraint->new;
+
+sub bar_hello { 'Hello, Bar!' }
+
+1;


### PR DESCRIPTION
This pull request provides the method get type constraints list, it is useful for exporting type constraints by `%EXPORT_TAGS`. Here is an example code:

```perl
    package MyBar {
        use Exporter 'import';
        use Types::Common -types;
        use kura Bar1 => StrLength[1, 255];
        use kura Bar2 => StrLength[1, 1000];

        our %EXPORT_TAGS = (
            types => \@MyBar::KURA,
        );
    }

    use MyBar qw(:types);
    # => Bar1, Bar2 are exported
```