### PR TITLE
Feature: store private constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ use MyBar qw(:types);
 # => Bar1, Bar2 are exported
 ```
 
+If you don't want to export constraints, put a prefix `_` to the constraint name:
+
+```perl
+use kura _PrivateFoo => Str;
+# => "_PrivateFoo" is not exported
+```
+
 # LICENSE
 
 Copyright (C) kobaken.

--- a/lib/kura.pm
+++ b/lib/kura.pm
@@ -71,7 +71,10 @@ sub _new_kura_item {
         }
     }
 
-    my $kura_item = { name => $name, code => sub { $constraint } };
+    # Prefix '_' means private, so it is not exported.
+    my $is_private = $name =~ /^_/ ? 1 : 0;
+
+    my $kura_item = { name => $name, code => sub { $constraint }, is_private => $is_private };
     return ($kura_item, undef);
 }
 
@@ -79,13 +82,14 @@ sub _new_kura_item {
 sub _save_kura_item {
     my ($kura_item, $caller) = @_;
 
-    {
-        my $name = $kura_item->{name};
-        my $code = Sub::Util::set_subname("$caller\::$name", $kura_item->{code});
+    my $name = $kura_item->{name};
+    my $code = Sub::Util::set_subname("$caller\::$name", $kura_item->{code});
 
-        no strict "refs";
-        no warnings "once";
-        *{"$caller\::$name"} = $code;
+    no strict "refs";
+    no warnings "once";
+    *{"$caller\::$name"} = $code;
+
+    if (!$kura_item->{is_private}) {
         push @{"$caller\::EXPORT_OK"}, $name;
         push @{"$caller\::KURA"}, $name;
     }
@@ -338,6 +342,11 @@ It is useful when you want to export constraints. For example, you can tag C<@KU
 
     use MyBar qw(:types);
     # => Bar1, Bar2 are exported
+
+If you don't want to export constraints, put a prefix C<_> to the constraint name:
+
+    use kura _PrivateFoo => Str;
+    # => "_PrivateFoo" is not exported
 
 =head1 LICENSE
 

--- a/t/01-kura.t
+++ b/t/01-kura.t
@@ -23,6 +23,14 @@ subtest 'Test `kura` features' => sub {
         is \@MyBar::KURA, [qw(Bar1 Bar2 Bar3)], 'types defined by kura are stored in $PACKAGE::KURA';
         is \@MyBar::EXPORT_OK, [qw(Bar1 Bar2 Bar3 bar_hello)];
     };
+
+    subtest '`kura` with private constraint' => sub {
+        use MyFoo qw(call_private_foo);
+        ok lives { call_private_foo() }; # _PrivateFoo is called at `call_private_foo`
+
+        eval 'use MyFoo qw(_PrivateFoo)';
+        like $@, qr/^"_PrivateFoo" is not exported by the MyFoo module/;
+    };
 };
 
 subtest 'Test `kura` exceptions' => sub {

--- a/t/lib/MyFoo.pm
+++ b/t/lib/MyFoo.pm
@@ -1,7 +1,7 @@
 package MyFoo;
 
 our @EXPORT_OK;
-push @EXPORT_OK, qw(hello);
+push @EXPORT_OK, qw(hello call_private_foo);
 
 use lib 't/lib';
 use MyConstraint;
@@ -9,7 +9,12 @@ use MyConstraint;
 use Exporter 'import';
 
 use kura Foo => MyConstraint->new;
+use kura _PrivateFoo => MyConstraint->new; # not exported
 
 sub hello { 'Hello, Foo!' }
+
+sub call_private_foo {
+    _PrivateFoo->check();
+}
 
 1;


### PR DESCRIPTION
This pull requests provides storing private constraints feature:

```perl
    use kura _PrivateFoo => Str;
    # => "_PrivateFoo" is not exported
```

Internally, If put a prefix `_`, then do not push `@EXPORT_OK` and `@KURA`.