### PR TITLE
Assign name for anon type tiny

### DIFF
--- a/lib/kura.pm
+++ b/lib/kura.pm
@@ -48,6 +48,7 @@ sub create_constraint {
     my ($constraint, $opts) = @_;
 
     if (my $blessed = Scalar::Util::blessed($constraint)) {
+        return _create_constraint_from_typetiny($constraint, $opts) if $constraint->isa('Type::Tiny');
         return ($constraint, undef) if $constraint->can('check');
         return ($constraint, undef) if grep { $constraint->isa($_) } @ALLOWED_CONSTRAINT_CLASSES;
         return (undef, "Invalid constraint. Object must have a `check` method or allowed constraint class: $blessed");
@@ -64,6 +65,15 @@ sub create_constraint {
     return (undef, 'Invalid constraint');
 }
 
+# Create a constraint object from a Type::Tiny object.
+sub _create_constraint_from_typetiny {
+    my ($type, $opts) = @_;
+
+    $type->{name} = $opts->{name} if $type->is_anon;
+
+    return ($type, undef);
+}
+
 # Create a constraint object from a code reference.
 sub _create_constraint_from_coderef {
     my ($coderef, $opts) = @_;
@@ -72,7 +82,6 @@ sub _create_constraint_from_coderef {
 
     my $args = {};
     $args->{name} = $opts->{name};
-    $args->{caller} = $opts->{caller};
     $args->{constraint} = sub { !!eval { $coderef->($_[0]) } };
     $args->{message} = sub { sprintf('%s did not pass the constraint "%s"', Type::Tiny::_dd($_[0]), $args->{name}) };
 
@@ -86,8 +95,7 @@ sub _create_constraint_from_hashref {
     my $blessed = delete $args->{blessed} || 'Type::Tiny';
     eval "require $blessed" or die $@;
 
-    $args->{name}   //= $opts->{name};
-    $args->{caller} //= $opts->{caller};
+    $args->{name} //= $opts->{name};
 
     return ($blessed->new(%$args), undef);
 }

--- a/t/10-integration/Type-Tiny/TestTypeTiny.pm
+++ b/t/10-integration/Type-Tiny/TestTypeTiny.pm
@@ -3,14 +3,19 @@ package TestTypeTiny;
 use Exporter 'import';
 use Types::Standard qw(Str);
 
-use kura Foo => Type::Tiny->new(
+use kura NamedType => Type::Tiny->new(
+    name => 'NamedType',
     constraint => sub { length $_ > 0 },
 );
 
-use kura Bar => sub { length $_ > 0 };
+use kura NoNameType  => Type::Tiny->new(
+    constraint => sub { length $_ > 0 },
+);
 
-use kura Baz => {
-    parent => Foo,
+use kura CodeRefType => sub { length $_ > 0 };
+
+use kura HashRefType => {
+    parent => NamedType,
     message => sub { "too short" },
 };
 

--- a/t/10-integration/Type-Tiny/basic.t
+++ b/t/10-integration/Type-Tiny/basic.t
@@ -4,30 +4,38 @@ use Test2::Require::Module 'Type::Tiny', '2.000000';
 use FindBin qw($Bin);
 use lib "$Bin";
 
-use TestTypeTiny qw(Foo Bar Baz);
+use TestTypeTiny qw(NamedType NoNameType CodeRefType HashRefType);
 
 subtest 'Test `kura` with Type::Tiny' => sub {
-    for my $type (Foo, Bar, Baz) {
+    for my $type (NamedType, NoNameType, CodeRefType HashRefType) {
         ok !$type->check('');
         ok $type->check('dog');
     }
 
-    is Foo, object {
-        prop blessed => 'Type::Tiny';
-        call name => '__ANON__';
+    is NamedType, object {
+        prop blessed      => 'Type::Tiny';
+        call name         => 'NamedType';
+        call display_name => 'NamedType';
     };
 
-    is Bar, object {
-        prop blessed => 'Type::Tiny';
-        call name => 'Bar';
+    is NoNameType, object {
+        prop blessed      => 'Type::Tiny';
+        call name         => 'NoNameType';
+        call display_name => 'NoNameType';
     };
 
-    is Baz, object {
-        prop blessed => 'Type::Tiny';
-        call name => 'Baz';
+    is CodeRefType, object {
+        prop blessed      => 'Type::Tiny';
+        call name         => 'CodeRefType';
+        call display_name => 'CodeRefType';
     };
 
-    is +Baz->validate(''), 'too short', 'Bar has a message';
+    is HashRefType, object {
+        prop blessed      => 'Type::Tiny';
+        call name         => 'HashRefType';
+        call display_name => 'HashRefType';
+        call sub { $_[0]->validate('') }, 'too short';
+    };
 };
 
 done_testing;


### PR DESCRIPTION
This pull request provides name for anon Type::Tiny.

```perl
use kura Monday    => StrMatch[ qr/\Amonday\z/i ];
use kura Tuesday   => StrMatch[ qr/\Atuesday\z/i ];
use kura Wednesday => StrMatch[ qr/\Awednesday\z/i ];
use kura Thursday  => StrMatch[ qr/\Athursday\z/i ];
use kura Friday    => StrMatch[ qr/\Afriday\z/i ];
use kura Saturday  => StrMatch[ qr/\Asaturday\z/i ];
use kura Sunday    => StrMatch[ qr/\Asunday\z/i ];

use kura Weekday => Monday | Tuesday | Wednesday | Thursday | Friday;

say Weekday;
# =>
# BEFORE: StrMatch[ qr/\Amonday\z/i ] | StrMatch[ qr/\Atuesday\z/i ] | StrMatch[ qr/\Awednesday\z/i ] ...
# AFTER: Weekday
```