### PR TITLE
Fixed warning: Subroutine kura::create_constraint redefined

### DIFF
--- a/t/lib/mykura.pm
+++ b/t/lib/mykura.pm
@@ -12,6 +12,7 @@ sub import {
     my $caller = caller;
 
     no strict 'refs';
+    no warnings 'redefine';
     local *{"kura::create_constraint"} = \&create_constraint;
 
     kura->import_into($caller, $name, $args);


### PR DESCRIPTION
This pull request fixed the following warning:

> Subroutine kura::create_constraint redefined