### PR TITLE
Support Perl 5.42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         perl:
           [
+            "5.42",
             "5.40",
             "5.38",
             "5.36",
@@ -26,10 +27,10 @@ jobs:
             "5.16",
           ]
         include:
-          - perl: 5.40
+          - perl: 5.42
             coverage: true
             integration: true
-          - perl: 5.38
+          - perl: 5.40
             integration: true
 
     name: Perl ${{ matrix.perl }}


### PR DESCRIPTION
## Summary
- Add Perl 5.42 to the GitHub Actions test matrix
- Move coverage testing to 5.42 (latest version)
- Run integration tests on 5.42 and 5.40

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)